### PR TITLE
example pattern fix for relative url

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module.exports = {
   pluginOptions: {
     'style-resources-loader': {
       'patterns': [
-        path.resolve(__dirname, 'src/styles/abstracts/*.styl'),
+        path.resolve(__dirname, './src/styles/abstracts/*.styl'),
       ]
     }
   }


### PR DESCRIPTION
I had trouble using it with the example config, but managed to use the style-resource loader based on this: https://cli.vuejs.org/guide/css.html#automatic-imports

After that I tried again, with the extra ./ and it is working now.